### PR TITLE
Fix small bug in CalendarOverviewViewController

### DIFF
--- a/schulcloud/CalendarOverviewViewController.swift
+++ b/schulcloud/CalendarOverviewViewController.swift
@@ -50,13 +50,13 @@ class CalendarOverviewViewController: UIViewController {
         self.syncEvents()
     }
 
-    var todayInterval : DateInterval = {
+    var todayInterval : DateInterval {
         let now = Date()
         let today = Date(year:now.year, month: now.month, day: now.day)
         let oneDayChunk = TimeChunk(seconds: 0, minutes: 0, hours: 0, days: 1, weeks: 0, months: 0, years: 0)
         let tomorrow = today + oneDayChunk
         return DateInterval(start: now, end: tomorrow)
-    }()
+    }
     
     private func syncEvents() {
         CalendarEventHelper.syncEvents().onSuccess { result in


### PR DESCRIPTION
Fix bug that would prevent the overview of finding the current running event because it kept stored an outdated `todayInterval`.
The `todayInterval` is now a computed property, preventing having stored an interval that would be outdated.
