### PR TITLE
Fix issue where sync of file would not be displayed because of new sync

### DIFF
--- a/schulcloud/FileHelper.swift
+++ b/schulcloud/FileHelper.swift
@@ -329,9 +329,6 @@ class FileHelper {
 
 // MARK: Course folder structure management
 extension FileHelper {
-
-    static var courseFolderStructureChanged = Notification.Name(rawValue: "courseFolderStructureChangedName")
-
     static func processCourseUpdates(changes: [String: [(id: String, name: String)]]) {
         let rootObjectId = FileHelper.rootFolder.objectID
 
@@ -376,7 +373,6 @@ extension FileHelper {
             }
 
             context.saveWithResult()
-            NotificationCenter.default.post(Notification(name: courseFolderStructureChanged))
         }
     }
 

--- a/schulcloud/FilesViewController.swift
+++ b/schulcloud/FilesViewController.swift
@@ -21,7 +21,7 @@ import UIKit
 import CoreData
 import BrightFutures
 
-class FilesViewController: UITableViewController, NSFetchedResultsControllerDelegate {
+class FilesViewController: UITableViewController {
 
     var currentFolder: File!
     var fileSync = FileSync()
@@ -31,8 +31,6 @@ class FilesViewController: UITableViewController, NSFetchedResultsControllerDele
         
         if currentFolder == nil {
             currentFolder = FileHelper.rootFolder
-        } else if currentFolder.id == FileHelper.coursesDirectoryID {
-            NotificationCenter.default.addObserver(self, selector: #selector(courseStructureDidUpdate(notification:)), name: FileHelper.courseFolderStructureChanged, object: nil)
         }
 
         self.navigationItem.title = self.currentFolder.name
@@ -61,11 +59,7 @@ class FilesViewController: UITableViewController, NSFetchedResultsControllerDele
             }.asVoid()
         }
 
-        future.onSuccess { (_) in
-            DispatchQueue.main.async {
-                self.performFetch()
-            }
-        }.onFailure { (error) in
+        future.onFailure { (error) in
             print("Failure: \(error)")
         }.onComplete{ (_) in
             DispatchQueue.main.async {
@@ -108,12 +102,9 @@ class FilesViewController: UITableViewController, NSFetchedResultsControllerDele
 
 }
 
-//MARK: course change notification
-extension FilesViewController {
-    @objc func courseStructureDidUpdate(notification: Notification) {
-        DispatchQueue.main.async { [weak self] in
-            self?.performFetch()
-        }
+extension FilesViewController : NSFetchedResultsControllerDelegate {
+    func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
+        self.tableView.reloadData()
     }
 }
 


### PR DESCRIPTION
Because of the new sync, and the new way of handling background context, the `FilesViewController`would not be notified when files are downloaded or courses have been fetch.
For file download, it's fixed by having `FileHelper.updateDatabase` returning a future (since changes in DB are done in background queue), and binding it together with fetching.
For changes in courses, it's a bit trickier. The controller has no way of know when the changes are done, since the course folders sync after changes to courses are saved. To fix this problem, we now subscribe to a notification `courseFolderStructureChanged` to update the content of the `tableView` in the `FilesViewController`.