### PR TITLE
Fix bug preventing to use file provider

### DIFF
--- a/Common/Data/Model/File.swift
+++ b/Common/Data/Model/File.swift
@@ -210,6 +210,7 @@ extension File {
         let file = result.first ?? File(context: context)
         file.isDirectory = try data.value(for: "isDirectory")
         file.parentDirectory = parentFolder
+        file.lastReadAt = Date()
 
         if !result.isEmpty && file.isDirectory {
             file.downloadState = .downloaded

--- a/iOS-fileprovider/Info.plist
+++ b/iOS-fileprovider/Info.plist
@@ -22,6 +22,8 @@
 	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
+	<key>KEYCHAIN_GROUP</key>
+	<string>$(KEYCHAIN_GROUP)</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionFileProviderDocumentGroup</key>


### PR DESCRIPTION
This PR fixes an issue where the file provider process couldn't fetch the access token from Keychain because didn't have the Keychaingroup