### PR TITLE
Display placeholder when comment empty

### DIFF
--- a/Common/Data/Model/Submission.swift
+++ b/Common/Data/Model/Submission.swift
@@ -32,7 +32,7 @@ extension Submission: Pullable {
     }
 
     public func update(from object: ResourceData, with context: SynchronizationContext) throws {
-        self.comment = try? object.value(for: "comment")
+        self.comment = (try? object.value(for: "comment")  as String)?.trimmingCharacters(in: .whitespacesAndNewlines)
         self.grade = (try? object.value(for: "grade")) ?? 0
         self.gradeComment = try? object.value(for: "gradeComment")
         self.createdAt = try object.value(for: "createdAt")

--- a/iOS/Controllers/HomeworkList/HomeworkSubmitViewController.swift
+++ b/iOS/Controllers/HomeworkList/HomeworkSubmitViewController.swift
@@ -167,7 +167,13 @@ final class HomeworkSubmitViewController: UIViewController {
             self.navigationItem.setLeftBarButton(nil, animated: true)
         }
 
-        self.commentField.text = self.writableSubmission.comment ?? placeholder
+        if let comment = self.writableSubmission.comment,
+            !comment.isEmpty {
+            self.commentField.text = comment
+        } else {
+            self.commentField.text = placeholder
+        }
+
         self.filesTableView.reloadData()
         self.tableViewHeightConstraint.constant = self.filesTableView.contentSize.height
         self.contentView.setNeedsLayout()

--- a/iOS/Controllers/HomeworkList/HomeworkSubmitViewController.swift
+++ b/iOS/Controllers/HomeworkList/HomeworkSubmitViewController.swift
@@ -357,7 +357,7 @@ extension HomeworkSubmitViewController: UITextViewDelegate {
     }
 
     func textViewDidEndEditing(_ textView: UITextView) {
-        let content = textView.text ?? ""
+        let content = textView.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
         if let comment = submission.comment {
             if comment != content { write(content: content, to: submission) }


### PR DESCRIPTION
This PR fixes an issue when an empty comment field would not display the placeholder text.
