### PR TITLE
Fix back button no arrow

### DIFF
--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -44,19 +44,20 @@ public class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotification
         let offWhite = UIColor(white: 0.98, alpha: 1.0)
         let navigationBarAppearance = UINavigationBar.appearance()
 
+        navigationBarAppearance.tintColor = offWhite
+
         if #available(iOS 13, *) {
             let appearance = UINavigationBarAppearance()
             appearance.configureWithOpaqueBackground()
             appearance.backgroundColor = Brand.default.colors.primary
             appearance.largeTitleTextAttributes = [.foregroundColor: offWhite]
             appearance.titleTextAttributes = [.foregroundColor: offWhite]
-            appearance.backButtonAppearance.normal.titleTextAttributes = [.foregroundColor: offWhite]
+
             navigationBarAppearance.standardAppearance = appearance
             navigationBarAppearance.scrollEdgeAppearance = appearance
 
         } else {
             navigationBarAppearance.barTintColor = Brand.default.colors.primary
-            navigationBarAppearance.tintColor = offWhite
             navigationBarAppearance.titleTextAttributes = [.foregroundColor: offWhite]
             navigationBarAppearance.shadowImage = UIImage()
         }


### PR DESCRIPTION
This PR fixes an issue where back button would not display an arrow on iOS13